### PR TITLE
refactor: restructure crypto_file.go and fix decrypt bugs

### DIFF
--- a/aes_file/crypto_file.go
+++ b/aes_file/crypto_file.go
@@ -4,142 +4,212 @@ import (
 	"bufio"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
-	ecies "github.com/ecies/go/v2"
-	"github.com/schollz/progressbar/v3"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	ecies "github.com/ecies/go/v2"
+	"github.com/schollz/progressbar/v3"
 )
 
 const (
-	eachEncryptLen   = 1024 * 1024 * 10 // Unencrypted 1 byte, encrypted to 32 bytes  100MB
+	plainChunkSize   = 1024 * 1024 * 10 // 10MB raw chunk
+	aesBlockSize     = 16
 	aesKeySize       = 32
 	encryptedFileExt = ".cc"
-	decryptedFileExt = "decrypted_"
+	decryptedPrefix  = "decrypted_"
+
+	// ECIES-encrypted 32-byte AES key, hex-encoded.
+	// 65 (uncompressed pubkey) + 16 (IV) + 32 (ciphertext) + 16 (tag) = 129 bytes -> 258 hex chars.
+	wrappedKeyHexLen = 258
 )
 
-func EncryptFile(filePath string, publicKeyHex string) error {
-	f, err := os.Open(filePath)
+// PKCS7 always adds a full block when input is a multiple of the block size,
+// so each full plain chunk produces (plainChunkSize + aesBlockSize) ciphertext bytes,
+// then hex-encoded to twice the size.
+const encryptedChunkHexLen = (plainChunkSize + aesBlockSize) * 2
+
+// EncryptFile encrypts filePath with a fresh AES-256 key, then wraps the AES key
+// with the given ECIES public key and appends it (hex-encoded) to the output file.
+func EncryptFile(filePath, publicKeyHex string) error {
+	publicKey, err := ecies.NewPublicKeyFromHex(publicKeyHex)
 	if err != nil {
-		return fmt.Errorf("failed to open file: %v", err)
+		return fmt.Errorf("invalid public key: %w", err)
 	}
-	defer f.Close()
-	fileInfo, _ := f.Stat()
-	fileSize := fileInfo.Size()
+
+	aesKey := make([]byte, aesKeySize)
+	if _, err := rand.Read(aesKey); err != nil {
+		return fmt.Errorf("generate AES key: %w", err)
+	}
+
+	in, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
+	}
+	fileSize := info.Size()
 	fmt.Println("File size to be encrypted:", fileSize, "bytes")
 
-	forNum := fileSize / int64(eachEncryptLen) // encryption number
-	if fileSize%int64(eachEncryptLen) != 0 {
-		forNum++
-	}
-	//加密后存储的文件
-	encryptedFilePath := filepath.Base(filePath) + encryptedFileExt
-	encryptedFile, err := os.Create(encryptedFilePath)
+	outPath := filepath.Base(filePath) + encryptedFileExt
+	out, err := os.Create(outPath)
 	if err != nil {
-		return fmt.Errorf("failed to create encrypted file: %v", err)
+		return fmt.Errorf("create encrypted file: %w", err)
 	}
-	defer encryptedFile.Close()
+	defer out.Close()
 
-	writer := bufio.NewWriter(encryptedFile)
+	writer := bufio.NewWriter(out)
+	reader := bufio.NewReader(in)
 
-	// AES密钥加密
-	aesKey := make([]byte, aesKeySize)
-	rand.Read(aesKey)
-
-	// AES encryption Data
-	// For 16, 24, and 32-bit strings, they correspond to AES-128, AES-192, and AES-256 encryption methods, respectively
-
-	buffer := make([]byte, eachEncryptLen)
-	bar := progressbar.Default(forNum)
-	for i := int64(0); i < forNum; i++ {
-		n, err := f.Read(buffer)
+	err = streamChunks(reader, fileSize, plainChunkSize, func(plain []byte) error {
+		ct, err := EncryptByAes(plain, aesKey)
 		if err != nil {
-			return fmt.Errorf("failed to read file: %v", err)
+			return fmt.Errorf("encrypt chunk: %w", err)
 		}
-		encryptedData, err := EncryptByAes(buffer[:n], aesKey)
-		if err != nil {
-			return fmt.Errorf("failed to encrypt data: %v", err)
-		}
-		writer.WriteString(encryptedData)
-		writer.Flush()
-		bar.Add(1)
+		_, err = writer.WriteString(ct)
+		return err
+	})
+	if err != nil {
+		return err
 	}
-	// writer Last
-	publicKey, _ := ecies.NewPublicKeyFromHex(publicKeyHex)
-	cryptoPwdKey, _ := ecies.Encrypt(publicKey, aesKey)
-	writer.WriteString(hex.EncodeToString(cryptoPwdKey))
-	writer.Flush()
 
-	encryptedFileInfo, _ := encryptedFile.Stat()
-	fmt.Printf("File encryption successful. Encrypted file name: %s, File size: %v bytes \n", encryptedFilePath, encryptedFileInfo.Size())
+	wrapped, err := ecies.Encrypt(publicKey, aesKey)
+	if err != nil {
+		return fmt.Errorf("wrap AES key: %w", err)
+	}
+	if _, err := writer.WriteString(hex.EncodeToString(wrapped)); err != nil {
+		return fmt.Errorf("write wrapped key: %w", err)
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("flush output: %w", err)
+	}
+
+	if outInfo, err := out.Stat(); err == nil {
+		fmt.Printf("File encryption successful. Encrypted file name: %s, File size: %v bytes \n",
+			outPath, outInfo.Size())
+	}
 	return nil
 }
 
-func DecryptFile(filePath string, privateKeyHex string) (err error) {
-	var keySize int64 = 258
-	var eachEncryptLen int64 = 20971552
-	f, err := os.Open(filePath)
+// DecryptFile inverts EncryptFile, recovering the AES key from the file's
+// hex-encoded suffix using the given ECIES private key.
+func DecryptFile(filePath, privateKeyHex string) error {
+	privateKey, err := ecies.NewPrivateKeyFromHex(privateKeyHex)
 	if err != nil {
-		return fmt.Errorf("failed to open file: %v", err)
+		return fmt.Errorf("invalid private key: %w", err)
 	}
-	defer f.Close()
-	fileInfo, _ := f.Stat()
-	fileSize := fileInfo.Size()
+
+	in, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("stat file: %w", err)
+	}
+	fileSize := info.Size()
 	fmt.Println("File size to be decrypted:", fileSize, "bytes")
 
-	if fileSize < keySize {
-		return fmt.Errorf("file is too small to contain the AES key")
+	if fileSize < int64(wrappedKeyHexLen) {
+		return errors.New("file is too small to contain the AES key")
 	}
-	aesKeyBytes := make([]byte, keySize)
-	_, err = f.ReadAt(aesKeyBytes, fileSize-keySize)
+
+	aesKey, err := readWrappedKey(in, fileSize, privateKey)
 	if err != nil {
-		return fmt.Errorf("failed to read AES key: %v", err)
+		return err
 	}
 
-	aesKeyBytes, _ = hex.DecodeString(string(aesKeyBytes))
-	privateKey, _ := ecies.NewPrivateKeyFromHex(privateKeyHex)
-	aesKey, err := ecies.Decrypt(privateKey, aesKeyBytes)
+	outPath := decryptedPrefix + strings.TrimSuffix(filepath.Base(filePath), encryptedFileExt)
+	out, err := os.Create(outPath)
 	if err != nil {
-		return fmt.Errorf("decrypt aes fail : %v", err)
+		return fmt.Errorf("create decrypted file: %w", err)
 	}
-	decryptedFilePath := decryptedFileExt + strings.TrimSuffix(filepath.Base(filePath), encryptedFileExt)
-	decryptedFile, err := os.Create(decryptedFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to create decrypted file: %v", err)
-	}
-	defer decryptedFile.Close()
+	defer out.Close()
 
-	writer := bufio.NewWriter(decryptedFile)
-
-	dataSize := fileSize - keySize
-	forNum := dataSize / eachEncryptLen // encryption number
-	if dataSize%eachEncryptLen != 0 {
-		forNum++
+	if _, err := in.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek to start: %w", err)
 	}
 
-	_, err = f.Seek(0, os.SEEK_SET)
-	buffer := make([]byte, eachEncryptLen)
+	writer := bufio.NewWriter(out)
+	reader := bufio.NewReader(in)
+	dataSize := fileSize - int64(wrappedKeyHexLen)
 
-	bar := progressbar.Default(forNum)
-
-	for i := int64(0); i < forNum; i++ {
-		if i == forNum-1 { // Last iteration
-			buffer = make([]byte, dataSize%eachEncryptLen)
-		}
-		n, err := f.Read(buffer)
+	err = streamChunks(reader, dataSize, encryptedChunkHexLen, func(ct []byte) error {
+		plain, err := DecryptByAes(ct, aesKey)
 		if err != nil {
-			return fmt.Errorf("failed to read file: %v", err)
+			return fmt.Errorf("decrypt chunk: %w", err)
 		}
-		decryptedData, err := DecryptByAes(buffer[:n], aesKey)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt data: %v", err)
-		}
-		writer.Write(decryptedData)
-		writer.Flush()
-		bar.Add(1)
+		_, err = writer.Write(plain)
+		return err
+	})
+	if err != nil {
+		return err
 	}
-	decryptedFileInfo, _ := decryptedFile.Stat()
-	fmt.Printf("File decryption successful. Decrypted file name: %s, File size: %v bytes \n", decryptedFileInfo.Name(), decryptedFileInfo.Size())
+
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("flush output: %w", err)
+	}
+
+	if outInfo, err := out.Stat(); err == nil {
+		fmt.Printf("File decryption successful. Decrypted file name: %s, File size: %v bytes \n",
+			outInfo.Name(), outInfo.Size())
+	}
+	return nil
+}
+
+func readWrappedKey(f *os.File, fileSize int64, privateKey *ecies.PrivateKey) ([]byte, error) {
+	keyHex := make([]byte, wrappedKeyHexLen)
+	if _, err := f.ReadAt(keyHex, fileSize-int64(wrappedKeyHexLen)); err != nil {
+		return nil, fmt.Errorf("read wrapped key: %w", err)
+	}
+	wrapped, err := hex.DecodeString(string(keyHex))
+	if err != nil {
+		return nil, fmt.Errorf("decode wrapped key: %w", err)
+	}
+	aesKey, err := ecies.Decrypt(privateKey, wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("unwrap AES key: %w", err)
+	}
+	return aesKey, nil
+}
+
+// streamChunks reads exactly `total` bytes from r, calling fn on each chunk of
+// up to `chunkSize`. The final chunk may be shorter when total is not a
+// multiple of chunkSize.
+func streamChunks(r io.Reader, total, chunkSize int64, fn func([]byte) error) error {
+	if total == 0 {
+		return nil
+	}
+	count := total / chunkSize
+	if total%chunkSize != 0 {
+		count++
+	}
+	bar := progressbar.Default(count)
+	buf := make([]byte, chunkSize)
+	remaining := total
+	for i := int64(0); i < count; i++ {
+		n := chunkSize
+		if remaining < n {
+			n = remaining
+		}
+		chunk := buf[:n]
+		if _, err := io.ReadFull(r, chunk); err != nil {
+			return fmt.Errorf("read chunk: %w", err)
+		}
+		if err := fn(chunk); err != nil {
+			return err
+		}
+		remaining -= n
+		_ = bar.Add(1)
+	}
 	return nil
 }


### PR DESCRIPTION
- Extract streamChunks helper to unify chunk-iteration logic for both encrypt and decrypt, replacing duplicated read loops.
- Extract readWrappedKey helper for the trailing ECIES-wrapped AES key.
- Replace magic numbers with named constants (plainChunkSize, aesBlockSize, wrappedKeyHexLen) and derive encryptedChunkHexLen from them.

Bug fixes:
- DecryptFile failed on files whose plaintext size is an exact multiple of the 10MB chunk size: the last-iteration buffer became 0-length, causing an EOF read error. The new size-tracking loop handles divisible sizes.
- Replace f.Read with io.ReadFull so short reads no longer leave chunks partially populated.
- Stop silently swallowing errors from rand.Read, ECIES key parsing / encryption, hex decoding, and Seek; surface them with %w wrapping.
- Replace deprecated os.SEEK_SET with io.SeekStart.

https://claude.ai/code/session_01T3zRGKF7sU7XtkpXtJcNdM